### PR TITLE
Add MCN claims validation tracking and fix empty CSV columns

### DIFF
--- a/src/steps/validate-input-csvs/validate-input-csvs.ts
+++ b/src/steps/validate-input-csvs/validate-input-csvs.ts
@@ -98,7 +98,7 @@ export default async function validateInputCSVs(context: PipelineContext) {
         }
 
         rows[0] = normalizeClaimsColumns(rows[0])
-        const actualColumns = Object.keys(rows[0])
+        const actualColumns = Object.keys(rows[0]).filter(col => col.trim() !== '')
         const validColumns = VALID_COLUMNS.claims
         const invalidColumns = actualColumns.filter((col) => !validColumns.includes(col))
 
@@ -134,7 +134,7 @@ export default async function validateInputCSVs(context: PipelineContext) {
         continue
       }
 
-      const actualColumns = Object.keys(rows[0])
+      const actualColumns = Object.keys(rows[0]).filter(col => col.trim() !== '')
       const validColumns = VALID_COLUMNS[fileType]
       const invalidColumns = actualColumns.filter((col) => !validColumns.includes(col))
 


### PR DESCRIPTION
- Add MCID/language_id validation queries in processClaims()
- Store validation results in context.outputs.claimsProcessed[claimsSource]
- Fixed validateInputCSVs to filter out empty/whitespace column names before validation (trailing commas in headers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed CSV validation to ignore empty column headers, reducing false error detection.
  * Added validation checks to identify invalid media component IDs and language IDs during claims processing, with invalid IDs now included in processing results for review.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->